### PR TITLE
Standardize allele names

### DIFF
--- a/hlathena/peptide_dataset.py
+++ b/hlathena/peptide_dataset.py
@@ -95,7 +95,7 @@ class PeptideDataset(Dataset):
                 self.pep_df.insert(
                     loc=0,
                     column='ha__allele',
-                    value=self.pep_df[allele_col_name]
+                    value=self.clean_allele_names(self.pep_df[allele_col_name])
                 )
         elif allele_name is not None:
             if 'ha__allele' not in pep_df.columns:
@@ -307,3 +307,8 @@ class PeptideDataset(Dataset):
         else:
             peptide = ''.join([INVERSE_AA_MAP[aa.item()] for aa in dense])
         return peptide
+
+    @staticmethod
+    def clean_allele_names(alleles: Union[pd.Series, pd.DataFrame]):
+        replacements = ['\\*','HLA[-|*]',':', '[N|Q]$',' ','-']
+        return alleles.replace(replacements, '', regex=True)

--- a/tests/test_peptide_dataset.py
+++ b/tests/test_peptide_dataset.py
@@ -94,5 +94,15 @@ class TestPeptideDataset(unittest.TestCase):
         peptide_dataset_len_9_allele_a0101.subset_data(peplens=9, alleles='A0101')
         self.assertEqual(len(peptide_dataset_len_9_allele_a0101), 4)
 
+    def test_allele_standardization(self):
+        peptide_df = pd.DataFrame([['KSSFLSSPE', 'A*01:01'],
+                                   ['RTEAAFSYY', 'A*0101'],
+                                   ['ASPQTLVLY', 'A01:01'],
+                                   ['GVMLDDYIR', 'A0101'],
+                                   ['TVLCAAGQA', 'HLA-B*40:02'],
+                                   ], columns=['pep', 'allele'])
+        peptide_dataset = hlathena.PeptideDataset(peptide_df, allele_col_name='allele')
+        self.assertListEqual(peptide_dataset.get_alleles(), ['A0101', 'B4002'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Standardize allele names in the `ha__allele`. E.g. HLA-B*40:02 becomes B4002. Please let me know if there are more test cases I should add; I'm not really familiar with the standards.