### PR TITLE
Add chi-squared test for peptide lengths in two peptide datasets

### DIFF
--- a/hlathena/stat_tests.py
+++ b/hlathena/stat_tests.py
@@ -1,0 +1,27 @@
+"""Perform statistical tests on peptide datasets"""
+
+import pandas as pd
+import scipy.stats
+
+from hlathena.peptide_dataset import PeptideDataset
+
+
+def peptide_length_chi2(
+    peps1: PeptideDataset, peps2: PeptideDataset
+) -> scipy.stats.contingency.Chi2ContingencyResult:
+    """Perform a chi-squared test on the lengths of peptides in two peptide datasets.
+
+    Args:
+        peps1: The first peptide dataset to be compared.
+        peps2: The scond peptide dataset to be compared.
+
+    Returns:
+        A Chi2ContingencyResult containing the results of the test.
+    """
+
+    lengths = pd.concat(
+        [peps1.pep_df['ha__pep'].str.len().value_counts(),
+        peps2.pep_df['ha__pep'].str.len().value_counts()],
+        axis=1).fillna(0).astype(int)
+
+    return scipy.stats.chi2_contingency(lengths)

--- a/tests/test_stat_tests.py
+++ b/tests/test_stat_tests.py
@@ -1,0 +1,33 @@
+import unittest
+from matplotlib.axes import Axes
+from matplotlib.collections import PathCollection
+
+import pandas as pd
+
+from hlathena import PeptideDataset
+from hlathena.stat_tests import peptide_length_chi2
+
+class TestStatTests(unittest.TestCase):
+    def test_peptide_length_chi2_different(self):
+        peptide_dataset_1 = PeptideDataset(995 * [8 * 'A'] + 5 * [9 * 'A'])
+        peptide_dataset_2 = PeptideDataset(5 * [8 * 'A'] + 995 * [9 * 'A'])
+
+        chi2_values = peptide_length_chi2(peptide_dataset_1, peptide_dataset_2)
+        # The length distributions in the two dataset are very different; this should be reflected
+        # in the test statistic.
+        self.assertLess(chi2_values.pvalue, 0.01)
+
+    def test_peptide_length_chi2_similar(self):
+        peptide_dataset_1 = PeptideDataset(995 * [8 * 'A'] + 5 * [9 * 'A'])
+        peptide_dataset_2 = PeptideDataset(995 * [8 * 'A'] + 5 * [9 * 'A'])
+
+        chi2_values = peptide_length_chi2(peptide_dataset_1, peptide_dataset_2)
+        # The length distributions in the two dataset are exactly the same; this should be reflected
+        # in the test statistic.
+        self.assertAlmostEqual(chi2_values.pvalue, 1)
+        self.assertAlmostEqual(chi2_values.statistic, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This compares whether the distributions of lengths are very different between two peptide datasets.